### PR TITLE
Make a Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM node:20-slim AS base
+ENV PNPM_HOME="/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
+RUN corepack enable
+COPY . /app
+WORKDIR /app
+
+FROM base AS prod-deps
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --prod --frozen-lockfile
+
+FROM base AS build
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile
+RUN pnpm run build
+
+FROM base
+
+WORKDIR /app
+
+RUN ["pnpm", "install"]
+RUN ["pnpm", "build"]
+
+EXPOSE 4173
+CMD [ "pnpm", "run", "preview", "--host" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3'
+
+services:
+  randon_games:
+    build: .
+    container_name: "randon_games"
+    ports:
+      - target: 4173
+        published: 4173
+        protocol: tcp
+        mode: host
+    

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3'
 services:
   randon_games:
     build: .
-    container_name: "randon_games"
+    container_name: "radon_games"
     ports:
       - target: 4173
         published: 4173


### PR DESCRIPTION
This will make this image able to be packaged as a Docker container, which will be easier to deploy for users than having to manually set it up via `pnpm`.